### PR TITLE
Add Support for Merging Unstable Pull Requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ rules:                      # Array of rules
   - base: master            # Required. Target branch
     upstream: wei:master    # Required. Must be in the same fork network.
     mergeMethod: hardreset  # Optional, one of [none, merge, squash, rebase, hardreset], Default: none.
+    mergeUnstable: false    # Optional, merge pull request even when the mergeable_state is not clean. Default: false
   - base: dev
     upstream: master        # Required. Can be a branch in the same forked repo.
     assignees:              # Optional

--- a/lib/pull.js
+++ b/lib/pull.js
@@ -63,7 +63,7 @@ module.exports = class Pull {
       incomingPR.user.login === 'pull[bot]' &&
       incomingPR.mergeable !== false // mergeable can be null, in which case we can proceed to wait and retry
     ) {
-      const mergeableStatus = (incomingPR.mergeable && incomingPR.mergeable_state === 'clean') ? {
+      const mergeableStatus = (incomingPR.mergeable && (incomingPR.mergeable_state === 'clean' || (incomingPR.mergeable_state === 'unstable' && rule.mergeUnstable))) ? {
         mergeable: true,
         mergeable_state: 'clean',
         rebaseable: incomingPR.rebaseable

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -20,6 +20,9 @@ const fields = {
   mergeMethod: Joi.string().valid('none', 'merge', 'squash', 'rebase', 'hardreset')
     .description('Auto merge pull request using this merge method. one of [none, merge, squash, rebase, hardreset], Default: none'),
 
+  mergeUnstable: Joi.boolean()
+    .description('Merge pull request even when the mergeable state is not is not clean'),
+
   assignees: Joi.array().items(Joi.string())
     .description('Assignees for the pull requests'),
 
@@ -36,6 +39,7 @@ const ruleSchemaWithDeprecation = Joi.object().keys({
   autoMerge: fields.autoMerge.default(false), // Deprecated, use mergeMethod
   autoMergeHardReset: fields.autoMerge.default(false), // Deprecated, use mergeMethod
   mergeMethod: fields.mergeMethod.default('none'),
+  mergeUnstable: fields.mergeUnstable.default(false),
   assignees: fields.assignees.default([]),
   reviewers: fields.assignees.default([])
 }).options({ stripUnknown: true }).required()
@@ -50,6 +54,7 @@ const ruleSchema = Joi.object().keys({
   base: fields.branch.required(),
   upstream: fields.upstream.required(),
   mergeMethod: fields.mergeMethod.default('none'),
+  mergeUnstable: fields.mergeUnstable.default(false),
   assignees: fields.assignees.default([]),
   reviewers: fields.assignees.default([])
 }).options({ stripUnknown: true }).required()

--- a/package-lock.json
+++ b/package-lock.json
@@ -3460,7 +3460,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3481,12 +3482,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3501,17 +3504,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3628,7 +3634,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3640,6 +3647,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3654,6 +3662,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3661,12 +3670,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3685,6 +3696,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3765,7 +3777,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3777,6 +3790,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3862,7 +3876,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3898,6 +3913,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3917,6 +3933,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3960,12 +3977,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/test/pull.test.js
+++ b/test/pull.test.js
@@ -426,7 +426,6 @@ describe('pull - checkAutoMerge', () => {
       mergeable_state: 'unstable'
     })
     expect(github.pulls.get).toHaveBeenCalledTimes(0)
-    expect(github.pulls.get).toHaveBeenCalledWith({ owner: 'wei', repo: 'fork', pull_number: 12 })
     expect(github.pulls.merge).toHaveBeenCalledWith({ owner: 'wei', repo: 'fork', pull_number: 12, merge_method: 'merge' })
     expect(github.git.updateRef).not.toHaveBeenCalled()
   })

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -7,7 +7,7 @@ const validConfigs = [
   [{ version: '1', rules: [{ base: 'master', upstream: 'upstream:master', autoMerge: true }], label: 'pull' }],
   [{ version: '1', rules: [{ base: 'master', upstream: 'upstream:master', autoMerge: true, assignees: ['wei'] }] }],
   [{ version: '1', rules: [{ base: 'master', upstream: 'upstream:master', autoMerge: false, reviewers: ['wei'] }] }],
-  [{ version: '1', rules: [{ base: 'master', upstream: 'upstream:master', mergeMethod: 'squash' }] }],
+  [{ version: '1', rules: [{ base: 'master', upstream: 'upstream:master', mergeMethod: 'squash', mergeUnstable: true }] }],
   [{ version: '1', rules: [{ base: 'master', upstream: 'upstream:master', mergeMethod: 'hardreset', assignees: ['wei'] }] }],
   [{
     version: '1',
@@ -65,6 +65,7 @@ describe('schema', () => {
           autoMerge: false,
           autoMergeHardReset: false,
           mergeMethod: 'none',
+          mergeUnstable: false,
           assignees: [],
           reviewers: []
         }


### PR DESCRIPTION
This adds support for merging unstable pull requests; particularly useful in the case where users want to merge pull requests generated from this app but fails in their Github workflows (for example due to lack of credits). 

Fixes #173