### PR TITLE
spelling: mergeability

### DIFF
--- a/test/pull.test.js
+++ b/test/pull.test.js
@@ -374,7 +374,7 @@ describe('pull - checkAutoMerge', () => {
     )
   })
 
-  test('should not merge if mergeablity is null', async () => {
+  test('should not merge if mergeability is null', async () => {
     github.pulls.get.mockResolvedValueOnce({ data: { mergeable: null, mergeable_state: 'unknown' } })
 
     const pull = getPull()
@@ -393,7 +393,7 @@ describe('pull - checkAutoMerge', () => {
     expect(github.git.updateRef).not.toHaveBeenCalled()
   })
 
-  test('should assign conflict reviewer if mergeablity is false', async () => {
+  test('should assign conflict reviewer if mergeability is false', async () => {
     github.pulls.get.mockResolvedValueOnce({ data: { mergeable: false } })
 
     const pull = getPull()


### PR DESCRIPTION
Misspelling identified by the [check-spelling action](https://github.com/marketplace/actions/check-spelling) -- note: the spell checker is *not* included in this PR.

It reported: 
https://github.com/jsoref/pull/runs/660097611?check_suite_focus=true

(When there's a long list, I go through a process of building an expect list and then showing that the fixes clear the list of misspellings, but as there was only one, it didn't seem worth it. That said, if you're interested in the action, I'd be happy to offer it.)