### PR TITLE
Update GitHub actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,7 @@ jobs:
     name: Build and Push
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@4
     - uses: actions/setup-node@v1
       with:
         node-version: '16.x'


### PR DESCRIPTION
Two actions are currently used in CI:

* `actions/checkout`, which is configured to use the current version in the `master` branch.
  
  The `master` branch hasn't been updated in three years because the project migrated to use `main` as its default branch.

* `actions/setup-node`, which is configured to use `v1`.

  `v1` is causing deprecation warnings in CI due to its use of Node 12. `v3` is the current version.

To keep these updated, this PR migrates from `actions/checkout@master` to `actions/checkout@v4` and introduces a Dependabot configuration that will keep the versions up-to-date moving forward.

If this PR is merged, you can expect Dependabot to open a PR immediately to update `actions/setup-node` to the current version.