### PR TITLE
Enable multiple instances of pull[bot]

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,23 +14,26 @@ jobs:
         node-version: '16.x'
     - run: npm ci
     - run: npm test
+    - name: Compute repo name
+      id: repo
+      run: echo name=$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]') >> $GITHUB_OUTPUT
     - name: Login to GitHub Container Registry
       run: |
         echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
     - name: Build Docker Image
       run: |
-        docker pull ghcr.io/${{ github.repository }}:latest || :
-        docker build -t ghcr.io/${{ github.repository }}:latest . \
-          --cache-from ghcr.io/${{ github.repository }}:latest \
+        docker pull ghcr.io/${{ steps.repo.outputs.name }}:latest || :
+        docker build -t ghcr.io/${{ steps.repo.outputs.name }}:latest . \
+          --cache-from ghcr.io/${{ steps.repo.outputs.name }}:latest \
           --build-arg VCS_REF=${{ github.sha }} \
           --build-arg BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
     - name: Push Docker Image to GitHub Container Registry
       run: |
-        docker push ghcr.io/${{ github.repository }}:latest
+        docker push ghcr.io/${{ steps.repo.outputs.name }}:latest
     - name: Login to GitHub Package Registry
       run: |
         echo ${{ secrets.GITHUB_TOKEN }} | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
     - name: Push Docker Image to GitHub Package Registry
       run: |
-        docker tag ghcr.io/${{ github.repository }}:latest docker.pkg.github.com/${{ github.repository }}/pull:latest
-        docker push docker.pkg.github.com/${{ github.repository }}/pull:latest
+        docker tag ghcr.io/${{ steps.repo.outputs.name }}:latest docker.pkg.github.com/${{ steps.repo.outputs.name }}/pull:latest
+        docker push docker.pkg.github.com/${{ steps.repo.outputs.name }}/pull:latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
     - run: npm test
     - name: Login to GitHub Container Registry
       run: |
-        echo ${{ secrets.CR_PAT }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
+        echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
     - name: Build Docker Image
       run: |
         docker pull ghcr.io/${{ github.repository }}:latest || :

--- a/lib/get-config.js
+++ b/lib/get-config.js
@@ -60,7 +60,8 @@ async function getDefaultConfig (context) {
           {
             base: `${defaultBranch}`,
             upstream: `${upstreamOwner}:${defaultBranch}`,
-            mergeMethod: process.env.DEFAULT_MERGE_METHOD || 'hardreset'
+            mergeMethod: process.env.DEFAULT_MERGE_METHOD || 'hardreset',
+            mergeUnstable: process.env.MERGE_UNSTABLE || false
           }
         ]
       }

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -5,6 +5,6 @@ exports.getPRTitle = (ref, upstream) =>
 
 exports.getPRBody = (repoPath, prNumber) =>
   (prNumber
-    ? `See [Commits](/${repoPath}/pull/${prNumber}/commits) and [Changes](/${repoPath}/pull/${prNumber}/files) for more details.\n\n-----\nCreated by [<img src="https://prod.download/pull-18h-svg" valign="bottom"/> **pull[bot]**](https://github.com/wei/pull)`
-    : 'See Commits and Changes for more details.\n\n-----\nCreated by [<img src="https://prod.download/pull-18h-svg" valign="bottom"/> **pull[bot]**](https://github.com/wei/pull)') +
+    ? `See [Commits](/${repoPath}/pull/${prNumber}/commits) and [Changes](/${repoPath}/pull/${prNumber}/files) for more details.\n\n-----\nCreated by [<img src="https://prod.download/pull-18h-svg" valign="bottom"/> **${process.env.APP_NAME}[bot]**](https://github.com/wei/pull)`
+    : `See Commits and Changes for more details.\n\n-----\nCreated by [<img src="https://prod.download/pull-18h-svg" valign="bottom"/> **${process.env.APP_NAME}[bot]**](https://github.com/wei/pull)`) +
   '\n\n_Can you help keep this open source service alive? **[💖 Please sponsor : )](https://prod.download/pull-pr-sponsor)**_'

--- a/lib/pull.js
+++ b/lib/pull.js
@@ -83,7 +83,7 @@ module.exports = class Pull {
 
     if (rule && rule.mergeMethod !== 'none' &&
       incomingPR.state === 'open' &&
-      incomingPR.user.login === 'pull[bot]' &&
+      incomingPR.user.login === `${process.env.APP_NAME}[bot]` &&
       incomingPR.mergeable !== false // mergeable can be null, in which case we can proceed to wait and retry
     ) {
       const mergeableStatus = (incomingPR.mergeable && (incomingPR.mergeable_state === 'clean' || (incomingPR.mergeable_state === 'unstable' && rule.mergeUnstable)))
@@ -156,7 +156,7 @@ module.exports = class Pull {
     const res = await this.github.issues.listForRepo({
       owner: this.config.owner,
       repo: this.config.repo,
-      creator: 'pull[bot]',
+      creator: `${process.env.APP_NAME}[bot]`,
       per_page: 100
     })
     if (res.data.length > 0) {
@@ -168,7 +168,7 @@ module.exports = class Pull {
         })
         if (
           pr.data &&
-          pr.data.user.login === 'pull[bot]' &&
+          pr.data.user.login === `${process.env.APP_NAME}[bot]` &&
           pr.data.base.label.replace(`${this.config.owner}:`, '') === base.replace(`${this.config.owner}:`, '') &&
           pr.data.head.label.replace(`${this.config.owner}:`, '') === head.replace(`${this.config.owner}:`, '')
         ) {

--- a/lib/router.js
+++ b/lib/router.js
@@ -9,7 +9,7 @@ const GITHUB_CREDENTIALS = (process.env.CLIENT_ID && process.env.CLIENT_SECRET)
   : ''
 const getJSON = uri => requestPromise({
   uri,
-  headers: { 'User-Agent': process.env.APP_ID || 'pull[bot]' },
+  headers: { 'User-Agent': process.env.APP_ID || `${process.env.APP_NAME}[bot]` },
   json: true
 })
 

--- a/test/pull.test.js
+++ b/test/pull.test.js
@@ -132,7 +132,7 @@ describe('pull - routineCheck', () => {
         base: { ref: 'master' },
         head: { ref: 'master', label: 'upstream:master', sha: 'sha1-placeholder-12' },
         state: 'open',
-        user: { login: 'pull[bot]' },
+        user: { login: `${process.env.APP_NAME}[bot]` },
         mergeable: true,
         mergeable_state: 'clean'
       }
@@ -191,7 +191,7 @@ describe('pull - routineCheck', () => {
               base: { ref: 'master', label: 'wei:master' },
               head: { ref: 'master', label: 'upstream:master', sha: 'sha1-placeholder-12' },
               state: 'open',
-              user: { login: 'pull[bot]' },
+              user: { login: `${process.env.APP_NAME}[bot]` },
               mergeable: true,
               rebaseable: true,
               mergeable_state: 'clean'
@@ -204,7 +204,7 @@ describe('pull - routineCheck', () => {
               base: { ref: 'feature/new-1', label: 'wei:feature/new-1' },
               head: { ref: 'dev', label: 'upstream:dev', sha: 'sha1-placeholder-13' },
               state: 'open',
-              user: { login: 'pull[bot]' },
+              user: { login: `${process.env.APP_NAME}[bot]` },
               mergeable: true,
               rebaseable: true,
               mergeable_state: 'clean'
@@ -217,7 +217,7 @@ describe('pull - routineCheck', () => {
               base: { ref: 'hotfix/bug-1', label: 'wei:hotfix/bug-1' },
               head: { ref: 'dev', label: 'upstream:dev', sha: 'sha1-placeholder-14' },
               state: 'open',
-              user: { login: 'pull[bot]' },
+              user: { login: `${process.env.APP_NAME}[bot]` },
               mergeable: true,
               rebaseable: true,
               mergeable_state: 'clean'
@@ -272,7 +272,7 @@ describe('pull - routineCheck', () => {
         base: { ref: 'master', label: 'wei:master' },
         head: { ref: 'master', label: 'upstream:master', sha: 'sha1-placeholder' },
         state: 'open',
-        user: { login: 'pull[bot]' },
+        user: { login: `${process.env.APP_NAME}[bot]` },
         mergeable: true,
         rebaseable: true,
         mergeable_state: 'clean'
@@ -325,7 +325,7 @@ describe('pull - checkAutoMerge', () => {
       base: { ref: 'master', label: 'wei:master' },
       head: { ref: 'master', label: 'upstream:master' },
       state: 'open',
-      user: { login: 'pull[bot]' },
+      user: { login: `${process.env.APP_NAME}[bot]` },
       mergeable: true,
       rebaseable: true,
       mergeable_state: 'clean'
@@ -341,7 +341,7 @@ describe('pull - checkAutoMerge', () => {
       base: { ref: 'feature/new-1' },
       head: { ref: 'dev', label: 'upstream:dev', sha: 'sha1-placeholder' },
       state: 'open',
-      user: { login: 'pull[bot]' },
+      user: { login: `${process.env.APP_NAME}[bot]` },
       mergeable: null,
       rebaseable: false,
       mergeable_state: 'unknown'
@@ -363,7 +363,7 @@ describe('pull - checkAutoMerge', () => {
       base: { ref: 'hotfix/bug-1' },
       head: { ref: 'dev', label: 'upstream:dev', sha: 'sha1-placeholder' },
       state: 'open',
-      user: { login: 'pull[bot]' },
+      user: { login: `${process.env.APP_NAME}[bot]` },
       mergeable: null,
       mergeable_state: 'unknown'
     })
@@ -384,7 +384,7 @@ describe('pull - checkAutoMerge', () => {
       base: { ref: 'feature/new-1' },
       head: { ref: 'dev', label: 'upstream:dev', sha: 'sha1-placeholder' },
       state: 'open',
-      user: { login: 'pull[bot]' },
+      user: { login: `${process.env.APP_NAME}[bot]` },
       mergeable: null,
       rebaseable: false,
       mergeable_state: 'unknown'
@@ -403,7 +403,7 @@ describe('pull - checkAutoMerge', () => {
       base: { ref: 'feature/new-1' },
       head: { ref: 'dev', label: 'upstream:dev', sha: 'sha1-placeholder' },
       state: 'open',
-      user: { login: 'pull[bot]' },
+      user: { login: `${process.env.APP_NAME}[bot]` },
       mergeable: false
     }, { conflictReviewers: ['wei', 'saurabh702'] })
 
@@ -429,7 +429,7 @@ describe('pull - checkAutoMerge', () => {
       base: { ref: 'feature/new-1' },
       head: { ref: 'dev', label: 'upstream:dev', sha: 'sha1-placeholder' },
       state: 'open',
-      user: { login: 'pull[bot]' },
+      user: { login: `${process.env.APP_NAME}[bot]` },
       mergeable: null,
       mergeable_state: 'unknown'
     }, { isMergeableMaxRetries: 2 })
@@ -448,7 +448,7 @@ describe('pull - checkAutoMerge', () => {
       base: { ref: 'dev' },
       head: { ref: 'master', label: 'wei:master', sha: 'sha1-placeholder' },
       state: 'open',
-      user: { login: 'pull[bot]' },
+      user: { login: `${process.env.APP_NAME}[bot]` },
       mergeable: true,
       rebaseable: false,
       mergeable_state: 'unstable'
@@ -468,7 +468,7 @@ describe('pull - checkAutoMerge', () => {
       base: { ref: 'hotfix/bug-1' },
       head: { ref: 'dev', label: 'upstream:dev', sha: 'sha1-placeholder' },
       state: 'open',
-      user: { login: 'pull[bot]' },
+      user: { login: `${process.env.APP_NAME}[bot]` },
       mergeable: null,
       rebaseable: false,
       mergeable_state: 'unknown'
@@ -490,7 +490,7 @@ describe('pull - checkAutoMerge', () => {
       base: { ref: 'dev' },
       head: { ref: 'master', label: 'wei:master', sha: 'sha1-placeholder' },
       state: 'open',
-      user: { login: 'pull[bot]' },
+      user: { login: `${process.env.APP_NAME}[bot]` },
       mergeable: null,
       rebaseable: false,
       mergeable_state: 'unknown'
@@ -511,7 +511,7 @@ describe('pull - checkAutoMerge', () => {
       base: { ref: 'dev' },
       head: { ref: 'master', label: 'wei:master', sha: 'sha1-placeholder' },
       state: 'open',
-      user: { login: 'pull[bot]' },
+      user: { login: `${process.env.APP_NAME}[bot]` },
       mergeable: null,
       rebaseable: false,
       mergeable_state: 'unknown'
@@ -532,7 +532,7 @@ describe('pull - checkAutoMerge', () => {
       base: { ref: 'dev' },
       head: { ref: 'master', label: 'wei:master', sha: 'sha1-placeholder' },
       state: 'open',
-      user: { login: 'pull[bot]' },
+      user: { login: `${process.env.APP_NAME}[bot]` },
       mergeable: null,
       rebaseable: false,
       mergeable_state: 'unknown'
@@ -553,7 +553,7 @@ describe('pull - checkAutoMerge', () => {
       base: { ref: 'dev' },
       head: { ref: 'master', label: 'wei:master', sha: 'sha1-placeholder' },
       state: 'open',
-      user: { login: 'pull[bot]' },
+      user: { login: `${process.env.APP_NAME}[bot]` },
       mergeable: null,
       rebaseable: false,
       mergeable_state: 'unknown'


### PR DESCRIPTION
The goal of this PR is to enable a custom bot name, which will allow hosting multiple `pull[bot]` instances.
This limitation is expected as there can be only one unique name for the GitHub app which is used to open and merge changes

- enable APP_NAME as parameter to set GitHub App name