### PR TITLE
fix: redis graceful exit and job cleanup

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0.0-alpha.3",
+  "version": "2.0.0-alpha.4",
   "tasks": {
     "dev": "deno run --env-file --allow-all src/index.ts",
     "dev:skip-full-sync": "deno task dev --skip-full-sync",

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,6 +56,12 @@ Deno.addSignalListener("SIGTERM", () => handleAppTermination("SIGTERM"));
 function handleAppTermination(signal: string) {
   log.info(`[${signal}] Signal received: closing MongoDB connection`);
   disconnectMongoDB();
+  try {
+    // Close Redis connection to avoid lingering connections
+    redisClient.quit();
+  } catch {
+    // ignore
+  }
   log.info("[MongoDB] Connection closed due to app termination");
   Deno.exit(0);
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Configurable job retention for the scheduler worker (removeOnComplete/removeOnFail with age/count) to auto-prune completed/failed jobs.

- Bug Fixes
  - Prevents lingering Redis connections by gracefully closing Redis during app termination, full sync, and worker shutdown.

- Chores
  - Improved shutdown robustness with safe, error-tolerant Redis cleanup.
  - Bumped Deno config version (alpha.3 → alpha.4).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->