### PR TITLE
spelling: set up

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ to yours using **hard reset** periodically. You can also manually
 ### Advanced Configuration (with config file)
 
 1. Create a new branch.
-2. Setup the new branch as default branch under repository Settings > Branches.
+2. Set up the new branch as default branch under repository Settings > Branches.
 3. Add `.github/pull.yml` to your default branch.
 
    #### Most Common


### PR DESCRIPTION
`Setup` is a noun, but the sentence wants to use a verb ([set up](https://www.merriam-webster.com/dictionary/setup#dictionary-entry-2)).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved wording in the Advanced Configuration instructions, clarifying the step for setting the default branch. This grammatical cleanup enhances readability and reduces ambiguity for users following setup steps. No behavioral or functional changes were introduced, and existing workflows remain unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->